### PR TITLE
Fix istio mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the packet mark.
 |------------|------------------------------|----------------------------------|
 | Any        | [OpenShift][openshift-ovn]   | [Source code][openshift-ovn-src] |
 | 0x00000800 | [Antrea][antrea]             | [Documentation][antrea-src]      |
-| 0x1337     | [Istio][istio]               | [Documentation][istio-src]       |
+| 1337       | [Istio][istio]               | [Documentation][istio-src]       |
 | 0x1e7700ce | [AWS AppMesh][aws-appmesh]   | [Documentation][aws-appmesh-src] |
 
 [antrea]: https://github.com/vmware-tanzu/antrea


### PR DESCRIPTION
This is not a hex number, but in decimal

```console
$ INBOUND_TPROXY_MARK=${ISTIO_INBOUND_TPROXY_MARK:-1337}
$ iptables -t mangle -A ISTIO_DIVERT -j MARK --set-mark ${INBOUND_TPROXY_MARK}
$ iptables -t mangle -L ISTIO_DIVERT
Chain ISTIO_DIVERT (0 references)
target     prot opt source               destination         
MARK       all  --  anywhere             anywhere             MARK set 0x539
```